### PR TITLE
Fix memory_get boolean property call error

### DIFF
--- a/mcp_synaptic/memory/manager.py
+++ b/mcp_synaptic/memory/manager.py
@@ -112,7 +112,7 @@ class MemoryManager(LoggerMixin):
                 return None
 
             # Check if expired
-            if memory.is_expired():
+            if memory.is_expired:
                 # Remove expired memory
                 await self.storage.delete(key)
                 self.logger.debug("Removed expired memory", key=key)


### PR DESCRIPTION
## Summary
- Fixed critical bug in memory_get function where `memory.is_expired()` was called as method instead of property
- Bug caused "'bool' object is not callable" error preventing memory retrieval
- Changed `memory.is_expired()` to `memory.is_expired` in manager.py:115

## Test plan
- [x] Verify memory_get now works without errors
- [x] Confirm memory_list continues working as before
- [x] Test both expired and non-expired memory scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)